### PR TITLE
handle "add" update expression

### DIFF
--- a/dynamo_repository.go
+++ b/dynamo_repository.go
@@ -108,6 +108,9 @@ func (repository *Repository) UpdateWithContext(ctx context.Context, expression 
 	}
 
 	for expr, value := range values {
+		if expression == Add {
+			update.Add(expr, value)
+		}
 		if expression == Set {
 			update.Set(expr, value)
 		}

--- a/repository_update_test.go
+++ b/repository_update_test.go
@@ -153,6 +153,26 @@ var _ = Describe("Repository", func() {
 			err := repository.Update(SetExpr, key, updates)
 			Expect(err).To(BeNil())
 		})
+		It("should Update item with Add", func() {
+			key := Key().WithTableName(UserTableName).
+				WithHashKeyName("UUID").
+				WithHashKey("uuid")
+
+			dMock.Should().Update(
+				dMock.WithTable(key.TableName()),
+				dMock.WithMatch(
+					mock.InputExpect().
+						FieldEq("ElemCount", 1),
+				),
+			).Exec()
+
+			updates := map[string]interface{}{
+				"ElemCount": 1,
+			}
+
+			err := repository.Update(Add, key, updates)
+			Expect(err).To(BeNil())
+		})
 		It("should return in err in case of db err", func() {
 			key := Key().WithTableName(UserTableName).
 				WithHashKeyName("UUID").

--- a/update_expression.go
+++ b/update_expression.go
@@ -13,3 +13,7 @@ const SetIfNotExists UpdateExpression = "SetIfNotExists"
 
 // SetExpr performs a custom set expression, substituting the args into expr as in filter expressions.
 const SetExpr UpdateExpression = "SetExpr"
+
+// Add increments the path value in case of a number, or in case of a set it appends to that set.
+// If a prior value doesn't exist it will set the path to that value.
+const Add UpdateExpression = "ADD"


### PR DESCRIPTION
Use the `ADD` action in an update expression to add a new attribute and its values to an item.
If the attribute already exists, the behavior of `ADD` depends on the attribute's data type:

- If the attribute is a number, and the value you are adding is also a number, the value is mathematically added to the existing attribute. (If the value is a negative number, it is subtracted from the existing attribute.)

- If the attribute is a set, and the value you are adding is also a set, the value is appended to the existing set.