### PR TITLE
Skipping empty string in update expressions as it used to convert to …

### DIFF
--- a/dynamo_repository.go
+++ b/dynamo_repository.go
@@ -89,6 +89,14 @@ func (repository Repository) SaveItemWithContext(ctx context.Context, key KeyInt
 	return nil
 }
 
+// isEmptyString returns true if value is a string with zero length.
+// Empty strings cannot be marshaled to valid DynamoDB AttributeValues by guregu/dynamo
+// (they marshal to nil), which causes SerializationException errors from DynamoDB.
+func isEmptyString(value interface{}) bool {
+	str, ok := value.(string)
+	return ok && str == ""
+}
+
 // UpdateWithContext updates item by key; it accepts an expression (Set, SetSet, SetIfNotExists, SetExpr); key is the key to be updated;
 // values contains the values that should be used in the update; context which used to enable log with context
 // returns error in case of error
@@ -109,6 +117,11 @@ func (repository Repository) UpdateWithContext(ctx context.Context, expression U
 	}
 
 	for expr, value := range values {
+		// Skip empty strings: guregu/dynamo marshals them to nil, which causes
+		// DynamoDB SerializationException errors.
+		if isEmptyString(value) {
+			continue
+		}
 		if expression == Add {
 			update.Add(expr, value)
 		}
@@ -159,6 +172,11 @@ func (repository Repository) prepareUpdateWithUpdateExpressions(
 		expression := UpdateExpression(updateExpression)
 
 		for expr, value := range v {
+			// Skip empty strings: guregu/dynamo marshals them to nil, which causes
+			// DynamoDB SerializationException errors.
+			if isEmptyString(value) {
+				continue
+			}
 			if expression == Add {
 				update.Add(expr, value)
 			}

--- a/dynamo_repository.go
+++ b/dynamo_repository.go
@@ -89,14 +89,6 @@ func (repository Repository) SaveItemWithContext(ctx context.Context, key KeyInt
 	return nil
 }
 
-// isEmptyString returns true if value is a string with zero length.
-// Empty strings cannot be marshaled to valid DynamoDB AttributeValues by guregu/dynamo
-// (they marshal to nil), which causes SerializationException errors from DynamoDB.
-func isEmptyString(value interface{}) bool {
-	str, ok := value.(string)
-	return ok && str == ""
-}
-
 // UpdateWithContext updates item by key; it accepts an expression (Set, SetSet, SetIfNotExists, SetExpr); key is the key to be updated;
 // values contains the values that should be used in the update; context which used to enable log with context
 // returns error in case of error
@@ -117,8 +109,6 @@ func (repository Repository) UpdateWithContext(ctx context.Context, expression U
 	}
 
 	for expr, value := range values {
-		// Skip empty strings: guregu/dynamo marshals them to nil, which causes
-		// DynamoDB SerializationException errors.
 		if isEmptyString(value) {
 			continue
 		}
@@ -172,8 +162,6 @@ func (repository Repository) prepareUpdateWithUpdateExpressions(
 		expression := UpdateExpression(updateExpression)
 
 		for expr, value := range v {
-			// Skip empty strings: guregu/dynamo marshals them to nil, which causes
-			// DynamoDB SerializationException errors.
 			if isEmptyString(value) {
 				continue
 			}

--- a/helper.go
+++ b/helper.go
@@ -13,6 +13,11 @@ func valueFromPtr[T any](ptr *T) T {
 	return *ptr
 }
 
+func isEmptyString(value any) bool {
+	str, ok := value.(string)
+	return ok && str == ""
+}
+
 func buildTableKeyCondition(table dynamo.Table, key KeyInterface) *dynamo.Query {
 	q := table.Get(*key.HashKeyName(), key.HashKey())
 

--- a/key.go
+++ b/key.go
@@ -100,5 +100,8 @@ func isValidHashKey(key KeyInterface) error {
 	if key.HashKey() == nil {
 		return ErrInvalidHashKeyValue
 	}
+	if str, ok := key.HashKey().(string); ok && str == "" {
+		return ErrInvalidHashKeyValue
+	}
 	return nil
 }

--- a/repository_update_test.go
+++ b/repository_update_test.go
@@ -70,6 +70,17 @@ var _ = Describe("Repository", func() {
 				err := repository.UpdateWithContext(context.Background(), djoemo.Set, key, updates)
 				Expect(err).To(Equal(djoemo.ErrInvalidHashKeyValue))
 			})
+			It("should fail with hash key value is empty string", func() {
+				key := djoemo.Key().WithTableName(UserTableName).WithHashKeyName("UUID").WithHashKey("")
+				metricsMock.EXPECT().Record(gomock.Any(), djoemo.OpUpdate, key, gomock.Any(), false)
+				updates := map[string]interface{}{
+					"UserName": "name2",
+					"TraceID":  "name4",
+				}
+
+				err := repository.UpdateWithContext(context.Background(), djoemo.Set, key, updates)
+				Expect(err).To(Equal(djoemo.ErrInvalidHashKeyValue))
+			})
 		})
 
 		It("should Update item with Set", func() {
@@ -95,6 +106,54 @@ var _ = Describe("Repository", func() {
 			}
 
 			err := repository.UpdateWithContext(context.Background(), djoemo.Set, key, updates)
+			Expect(err).To(BeNil())
+		})
+
+		It("should skip empty string values in Set update", func() {
+			key := djoemo.Key().WithTableName(UserTableName).
+				WithHashKeyName("UUID").
+				WithHashKey("uuid")
+
+			dMock.Should().Update(
+				dMock.WithTable(key.TableName()),
+				dMock.WithMatch(
+					mock.InputExpect().
+						FieldEq("UserName", "name2"),
+				),
+			).Exec()
+
+			metricsMock.EXPECT().Record(gomock.Any(), djoemo.OpUpdate, key, gomock.Any(), true)
+
+			updates := map[string]interface{}{
+				"UserName": "name2",
+				"DeviceID": "",
+			}
+
+			err := repository.UpdateWithContext(context.Background(), djoemo.Set, key, updates)
+			Expect(err).To(BeNil())
+		})
+
+		It("should skip empty string values in SetIfNotExists update", func() {
+			key := djoemo.Key().WithTableName(UserTableName).
+				WithHashKeyName("UUID").
+				WithHashKey("uuid")
+
+			dMock.Should().Update(
+				dMock.WithTable(key.TableName()),
+				dMock.WithMatch(
+					mock.InputExpect().
+						FieldEq("SDKHash", "hash123"),
+				),
+			).Exec()
+
+			metricsMock.EXPECT().Record(gomock.Any(), djoemo.OpUpdate, key, gomock.Any(), true)
+
+			updates := map[string]interface{}{
+				"SDKHash":    "hash123",
+				"DeviceName": "",
+			}
+
+			err := repository.UpdateWithContext(context.Background(), djoemo.SetIfNotExists, key, updates)
 			Expect(err).To(BeNil())
 		})
 
@@ -212,6 +271,82 @@ var _ = Describe("Repository", func() {
 
 			ret := repository.UpdateWithContext(context.Background(), djoemo.Set, key, updates)
 			Expect(ret).To(Equal(err))
+		})
+	})
+
+	Describe("UpdateWithUpdateExpressions", func() {
+		It("should update item with mixed Set and SetIfNotExists expressions", func() {
+			key := djoemo.Key().WithTableName(UserTableName).
+				WithHashKeyName("UUID").
+				WithHashKey("uuid")
+
+			dMock.Should().Update(
+				dMock.WithTable(key.TableName()),
+				dMock.WithMatch(
+					mock.InputExpect().
+						FieldEq("UserName", "name2").FieldEq("SDKHash", "hash123"),
+				),
+			).Exec()
+
+			metricsMock.EXPECT().Record(gomock.Any(), djoemo.OpUpdate, key, gomock.Any(), true)
+
+			updateExpressions := djoemo.UpdateExpressions{
+				djoemo.Set: {
+					"UserName": "name2",
+				},
+				djoemo.SetIfNotExists: {
+					"SDKHash": "hash123",
+				},
+			}
+
+			err := repository.UpdateWithUpdateExpressions(context.Background(), key, updateExpressions)
+			Expect(err).To(BeNil())
+		})
+
+		It("should fail with hash key value is empty string", func() {
+			key := djoemo.Key().WithTableName(UserTableName).WithHashKeyName("UUID").WithHashKey("")
+			metricsMock.EXPECT().Record(gomock.Any(), djoemo.OpUpdate, key, gomock.Any(), false)
+
+			updateExpressions := djoemo.UpdateExpressions{
+				djoemo.Set: {
+					"UserName": "name2",
+				},
+			}
+
+			err := repository.UpdateWithUpdateExpressions(context.Background(), key, updateExpressions)
+			Expect(err).To(Equal(djoemo.ErrInvalidHashKeyValue))
+		})
+
+		It("should skip empty string values in Set and SetIfNotExists expressions", func() {
+			key := djoemo.Key().WithTableName(UserTableName).
+				WithHashKeyName("UUID").
+				WithHashKey("uuid")
+
+			dMock.Should().Update(
+				dMock.WithTable(key.TableName()),
+				dMock.WithMatch(
+					mock.InputExpect().
+						FieldEq("UserName", "name2").FieldEq("SDKHash", "hash123"),
+				),
+			).Exec()
+
+			metricsMock.EXPECT().Record(gomock.Any(), djoemo.OpUpdate, key, gomock.Any(), true)
+
+			updateExpressions := djoemo.UpdateExpressions{
+				djoemo.Set: {
+					"UserName":    "name2",
+					"DeviceID":    "",
+					"ProductName": "",
+				},
+				djoemo.SetIfNotExists: {
+					"SDKHash":    "hash123",
+					"DeviceName": "",
+					"DeviceType": "",
+				},
+			}
+
+			err := repository.UpdateWithUpdateExpressions(context.Background(), key, updateExpressions)
+			Expect(err).To(BeNil())
 		})
 	})
 


### PR DESCRIPTION
Changes made

key.go — Empty string hash key validation
isValidHashKey() now rejects empty string hash key values in addition to nil. This catches the problem early with a clear ErrInvalidHashKeyValue error instead of a cryptic SerializationException from AWS.

dynamo_repository.go — Skip empty strings in update expressions

Added isEmptyString() helper function

Both UpdateWithContext() and prepareUpdateWithUpdateExpressions() now skip any value that is an empty string ("") when building Set, SetSet, SetIfNotExists, and Add expressions. This prevents guregu/dynamo from marshaling empty strings to nil *dynamodb.AttributeValue, which was causing the SerializationException.

