### PR TITLE
revert #28 and add tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea
 vendor
 Gopkg.*
-.coverage
+.coverage*
+coverage*

--- a/dynamo_repository.go
+++ b/dynamo_repository.go
@@ -109,9 +109,6 @@ func (repository Repository) UpdateWithContext(ctx context.Context, expression U
 	}
 
 	for expr, value := range values {
-		if isEmptyString(value) {
-			continue
-		}
 		if expression == Add {
 			update.Add(expr, value)
 		}
@@ -162,9 +159,6 @@ func (repository Repository) prepareUpdateWithUpdateExpressions(
 		expression := UpdateExpression(updateExpression)
 
 		for expr, value := range v {
-			if isEmptyString(value) {
-				continue
-			}
 			if expression == Add {
 				update.Add(expr, value)
 			}

--- a/helper.go
+++ b/helper.go
@@ -13,11 +13,6 @@ func valueFromPtr[T any](ptr *T) T {
 	return *ptr
 }
 
-func isEmptyString(value any) bool {
-	str, ok := value.(string)
-	return ok && str == ""
-}
-
 func buildTableKeyCondition(table dynamo.Table, key KeyInterface) *dynamo.Query {
 	q := table.Get(*key.HashKeyName(), key.HashKey())
 

--- a/key.go
+++ b/key.go
@@ -100,8 +100,5 @@ func isValidHashKey(key KeyInterface) error {
 	if key.HashKey() == nil {
 		return ErrInvalidHashKeyValue
 	}
-	if str, ok := key.HashKey().(string); ok && str == "" {
-		return ErrInvalidHashKeyValue
-	}
 	return nil
 }

--- a/repository_batch_get_test.go
+++ b/repository_batch_get_test.go
@@ -1,0 +1,209 @@
+package djoemo_test
+
+import (
+	"context"
+	"errors"
+
+	"github.com/adjoeio/djoemo"
+	"github.com/adjoeio/djoemo/mock"
+	"github.com/aws/aws-sdk-go/service/dynamodb"
+	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbattribute"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"go.uber.org/mock/gomock"
+)
+
+var _ = Describe("Repository BatchGetItemsWithContext", func() {
+	const UserTableName = "UserTable"
+
+	var (
+		dAPIMock    *mock.MockDynamoDBAPI
+		repository  djoemo.RepositoryInterface
+		logMock     *mock.MockLogInterface
+		metricsMock *mock.MockMetricsInterface
+	)
+
+	BeforeEach(func() {
+		mockCtrl := gomock.NewController(GinkgoT())
+		dAPIMock = mock.NewMockDynamoDBAPI(mockCtrl)
+		logMock = mock.NewMockLogInterface(mockCtrl)
+		metricsMock = mock.NewMockMetricsInterface(mockCtrl)
+		repository = djoemo.NewRepository(dAPIMock)
+		repository.WithLog(logMock)
+		repository.WithMetrics(metricsMock)
+	})
+
+	It("should return false and nil when keys slice is empty", func() {
+		users := &[]User{}
+		found, err := repository.BatchGetItemsWithContext(context.Background(), []djoemo.KeyInterface{}, users)
+		Expect(err).To(BeNil())
+		Expect(found).To(BeFalse())
+	})
+
+	It("should return error when key has no table name", func() {
+		invalidKey := djoemo.Key().WithHashKeyName("UUID").WithHashKey("uuid")
+		metricsMock.EXPECT().Record(gomock.Any(), djoemo.OpRead, invalidKey, gomock.Any(), false)
+
+		users := &[]User{}
+		found, err := repository.BatchGetItemsWithContext(
+			context.Background(),
+			[]djoemo.KeyInterface{invalidKey},
+			users,
+		)
+		Expect(err).To(Equal(djoemo.ErrInvalidTableName))
+		Expect(found).To(BeFalse())
+	})
+
+	It("should return error when keys refer to different tables", func() {
+		key1 := djoemo.Key().WithTableName(UserTableName).
+			WithHashKeyName("UUID").WithHashKey("uuid1")
+		key2 := djoemo.Key().WithTableName("OtherTable").
+			WithHashKeyName("UUID").WithHashKey("uuid2")
+
+		// Note: success flag captured from outer err var which isn't
+		// updated for ErrInvalidBatchRequest return path.
+		metricsMock.EXPECT().Record(gomock.Any(), djoemo.OpRead, gomock.Any(), gomock.Any(), gomock.Any()).Times(2)
+
+		users := &[]User{}
+		found, err := repository.BatchGetItemsWithContext(
+			context.Background(),
+			[]djoemo.KeyInterface{key1, key2},
+			users,
+		)
+		Expect(err).To(Equal(djoemo.ErrInvalidBatchRequest))
+		Expect(found).To(BeFalse())
+	})
+
+	It("should return items when batch get succeeds by hash key", func() {
+		key1 := djoemo.Key().WithTableName(UserTableName).
+			WithHashKeyName("UUID").WithHashKey("uuid1")
+		key2 := djoemo.Key().WithTableName(UserTableName).
+			WithHashKeyName("UUID").WithHashKey("uuid2")
+
+		items := []map[string]*dynamodb.AttributeValue{}
+		for _, u := range []map[string]interface{}{
+			{"UUID": "uuid1", "UserName": "name1"},
+			{"UUID": "uuid2", "UserName": "name2"},
+		} {
+			av, _ := dynamodbattribute.MarshalMap(u)
+			items = append(items, av)
+		}
+		output := &dynamodb.BatchGetItemOutput{
+			Responses: map[string][]map[string]*dynamodb.AttributeValue{
+				UserTableName: items,
+			},
+		}
+
+		dAPIMock.EXPECT().
+			BatchGetItemWithContext(gomock.Any(), gomock.Any()).
+			Return(output, nil).
+			AnyTimes()
+
+		metricsMock.EXPECT().Record(gomock.Any(), djoemo.OpRead, key1, gomock.Any(), true)
+		metricsMock.EXPECT().Record(gomock.Any(), djoemo.OpRead, key2, gomock.Any(), true)
+
+		users := &[]User{}
+		found, err := repository.BatchGetItemsWithContext(
+			context.Background(),
+			[]djoemo.KeyInterface{key1, key2},
+			users,
+		)
+		Expect(err).To(BeNil())
+		Expect(found).To(BeTrue())
+		Expect(len(*users)).To(Equal(2))
+	})
+
+	It("should handle hash and range keys", func() {
+		key1 := djoemo.Key().WithTableName(UserTableName).
+			WithHashKeyName("UUID").WithHashKey("uuid1").
+			WithRangeKeyName("Email").WithRangeKey("a@adjoe.io")
+		key2 := djoemo.Key().WithTableName(UserTableName).
+			WithHashKeyName("UUID").WithHashKey("uuid2").
+			WithRangeKeyName("Email").WithRangeKey("b@adjoe.io")
+
+		items := []map[string]*dynamodb.AttributeValue{}
+		for _, u := range []map[string]interface{}{
+			{"UUID": "uuid1", "Email": "a@adjoe.io"},
+			{"UUID": "uuid2", "Email": "b@adjoe.io"},
+		} {
+			av, _ := dynamodbattribute.MarshalMap(u)
+			items = append(items, av)
+		}
+		output := &dynamodb.BatchGetItemOutput{
+			Responses: map[string][]map[string]*dynamodb.AttributeValue{
+				UserTableName: items,
+			},
+		}
+
+		dAPIMock.EXPECT().
+			BatchGetItemWithContext(gomock.Any(), gomock.Any()).
+			Return(output, nil).
+			AnyTimes()
+
+		metricsMock.EXPECT().Record(gomock.Any(), djoemo.OpRead, key1, gomock.Any(), true)
+		metricsMock.EXPECT().Record(gomock.Any(), djoemo.OpRead, key2, gomock.Any(), true)
+
+		profiles := &[]Profile{}
+		found, err := repository.BatchGetItemsWithContext(
+			context.Background(),
+			[]djoemo.KeyInterface{key1, key2},
+			profiles,
+		)
+		Expect(err).To(BeNil())
+		Expect(found).To(BeTrue())
+		Expect(len(*profiles)).To(Equal(2))
+	})
+
+	It("should return false and nil when dynamo returns ErrNotFound", func() {
+		key := djoemo.Key().WithTableName(UserTableName).
+			WithHashKeyName("UUID").WithHashKey("uuid")
+
+		output := &dynamodb.BatchGetItemOutput{
+			Responses: map[string][]map[string]*dynamodb.AttributeValue{
+				UserTableName: {},
+			},
+		}
+
+		dAPIMock.EXPECT().
+			BatchGetItemWithContext(gomock.Any(), gomock.Any()).
+			Return(output, nil).
+			AnyTimes()
+
+		metricsMock.EXPECT().Record(gomock.Any(), djoemo.OpRead, key, gomock.Any(), true)
+		logMock.EXPECT().WithContext(gomock.Any()).Return(logMock)
+		logMock.EXPECT().WithField(djoemo.TableName, UserTableName).Return(logMock)
+		logMock.EXPECT().Info(djoemo.ErrNoItemFound.Error())
+
+		users := &[]User{}
+		found, err := repository.BatchGetItemsWithContext(
+			context.Background(),
+			[]djoemo.KeyInterface{key},
+			users,
+		)
+		Expect(err).To(BeNil())
+		Expect(found).To(BeFalse())
+	})
+
+	It("should return false and error when dynamo returns an error", func() {
+		key := djoemo.Key().WithTableName(UserTableName).
+			WithHashKeyName("UUID").WithHashKey("uuid")
+
+		dbErr := errors.New("some dynamo error")
+
+		dAPIMock.EXPECT().
+			BatchGetItemWithContext(gomock.Any(), gomock.Any()).
+			Return(nil, dbErr).
+			AnyTimes()
+
+		metricsMock.EXPECT().Record(gomock.Any(), djoemo.OpRead, key, gomock.Any(), false)
+
+		users := &[]User{}
+		found, err := repository.BatchGetItemsWithContext(
+			context.Background(),
+			[]djoemo.KeyInterface{key},
+			users,
+		)
+		Expect(err).To(HaveOccurred())
+		Expect(found).To(BeFalse())
+	})
+})

--- a/repository_update_expressions_test.go
+++ b/repository_update_expressions_test.go
@@ -1,0 +1,303 @@
+package djoemo_test
+
+import (
+	"context"
+	"errors"
+
+	"github.com/adjoeio/djoemo"
+	"github.com/adjoeio/djoemo/mock"
+	awserr "github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/dynamodb"
+	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbattribute"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"go.uber.org/mock/gomock"
+)
+
+var _ = Describe("Repository UpdateWithUpdateExpressions", func() {
+	const UserTableName = "UserTable"
+
+	var (
+		dAPIMock    *mock.MockDynamoDBAPI
+		repository  djoemo.RepositoryInterface
+		logMock     *mock.MockLogInterface
+		metricsMock *mock.MockMetricsInterface
+	)
+
+	BeforeEach(func() {
+		mockCtrl := gomock.NewController(GinkgoT())
+		dAPIMock = mock.NewMockDynamoDBAPI(mockCtrl)
+		logMock = mock.NewMockLogInterface(mockCtrl)
+		metricsMock = mock.NewMockMetricsInterface(mockCtrl)
+		repository = djoemo.NewRepository(dAPIMock)
+		repository.WithLog(logMock)
+		repository.WithMetrics(metricsMock)
+	})
+
+	Describe("UpdateWithUpdateExpressions", func() {
+		It("should fail with invalid key", func() {
+			key := djoemo.Key().WithHashKeyName("UUID").WithHashKey("uuid")
+			metricsMock.EXPECT().Record(gomock.Any(), djoemo.OpUpdate, key, gomock.Any(), false)
+
+			updates := djoemo.UpdateExpressions{
+				djoemo.Set: {"UserName": "name"},
+			}
+
+			err := repository.UpdateWithUpdateExpressions(context.Background(), key, updates)
+			Expect(err).To(Equal(djoemo.ErrInvalidTableName))
+		})
+
+		It("should update with multiple expression types", func() {
+			key := djoemo.Key().WithTableName(UserTableName).
+				WithHashKeyName("UUID").WithHashKey("uuid").
+				WithRangeKeyName("Email").WithRangeKey("mail@adjoe.io")
+
+			dAPIMock.EXPECT().
+				UpdateItemWithContext(gomock.Any(), gomock.Any()).
+				Return(&dynamodb.UpdateItemOutput{}, nil).
+				AnyTimes()
+
+			metricsMock.EXPECT().Record(gomock.Any(), djoemo.OpUpdate, key, gomock.Any(), true)
+
+			updates := djoemo.UpdateExpressions{
+				djoemo.Set:            {"UserName": "name"},
+				djoemo.Add:            {"Counter": 1},
+				djoemo.SetSet:         {"Tags": []string{"a"}},
+				djoemo.SetIfNotExists: {"TraceID": "trace"},
+			}
+
+			err := repository.UpdateWithUpdateExpressions(context.Background(), key, updates)
+			Expect(err).To(BeNil())
+		})
+
+		It("should update with SetExpr", func() {
+			key := djoemo.Key().WithTableName(UserTableName).
+				WithHashKeyName("UUID").WithHashKey("uuid")
+
+			dAPIMock.EXPECT().
+				UpdateItemWithContext(gomock.Any(), gomock.Any()).
+				Return(&dynamodb.UpdateItemOutput{}, nil).
+				AnyTimes()
+
+			metricsMock.EXPECT().Record(gomock.Any(), djoemo.OpUpdate, key, gomock.Any(), true)
+
+			updates := djoemo.UpdateExpressions{
+				djoemo.SetExpr: {"Meta.$ = ?": []interface{}{"foo", "bar"}},
+			}
+
+			err := repository.UpdateWithUpdateExpressions(context.Background(), key, updates)
+			Expect(err).To(BeNil())
+		})
+
+		It("should return error if SetExpr value is not a slice", func() {
+			key := djoemo.Key().WithTableName(UserTableName).
+				WithHashKeyName("UUID").WithHashKey("uuid")
+
+			metricsMock.EXPECT().Record(gomock.Any(), djoemo.OpUpdate, key, gomock.Any(), false)
+
+			updates := djoemo.UpdateExpressions{
+				djoemo.SetExpr: {"Meta.$ = ?": "not a slice"},
+			}
+
+			err := repository.UpdateWithUpdateExpressions(context.Background(), key, updates)
+			Expect(err).To(Equal(djoemo.ErrInvalidSliceType))
+		})
+
+		It("should return error when dynamodb fails", func() {
+			key := djoemo.Key().WithTableName(UserTableName).
+				WithHashKeyName("UUID").WithHashKey("uuid")
+
+			dbErr := errors.New("update failed")
+			dAPIMock.EXPECT().
+				UpdateItemWithContext(gomock.Any(), gomock.Any()).
+				Return(nil, dbErr).
+				AnyTimes()
+
+			metricsMock.EXPECT().Record(gomock.Any(), djoemo.OpUpdate, key, gomock.Any(), false)
+
+			updates := djoemo.UpdateExpressions{
+				djoemo.Set: {"UserName": "name"},
+			}
+
+			err := repository.UpdateWithUpdateExpressions(context.Background(), key, updates)
+			Expect(err).To(Equal(dbErr))
+		})
+	})
+
+	Describe("UpdateWithUpdateExpressionsAndReturnValue", func() {
+		It("should fail with invalid key", func() {
+			key := djoemo.Key().WithHashKeyName("UUID").WithHashKey("uuid")
+			metricsMock.EXPECT().Record(gomock.Any(), djoemo.OpUpdate, key, gomock.Any(), false)
+
+			user := &User{}
+			updates := djoemo.UpdateExpressions{
+				djoemo.Set: {"UserName": "name"},
+			}
+
+			err := repository.UpdateWithUpdateExpressionsAndReturnValue(context.Background(), key, user, updates)
+			Expect(err).To(Equal(djoemo.ErrInvalidTableName))
+		})
+
+		It("should update and return value", func() {
+			key := djoemo.Key().WithTableName(UserTableName).
+				WithHashKeyName("UUID").WithHashKey("uuid")
+
+			updated := map[string]interface{}{
+				"UUID":     "uuid",
+				"UserName": "new-name",
+			}
+			av, _ := dynamodbattribute.MarshalMap(updated)
+
+			dAPIMock.EXPECT().
+				UpdateItemWithContext(gomock.Any(), gomock.Any()).
+				Return(&dynamodb.UpdateItemOutput{Attributes: av}, nil).
+				AnyTimes()
+
+			metricsMock.EXPECT().Record(gomock.Any(), djoemo.OpUpdate, key, gomock.Any(), true)
+
+			user := &User{}
+			updates := djoemo.UpdateExpressions{
+				djoemo.Set: {"UserName": "new-name"},
+			}
+
+			err := repository.UpdateWithUpdateExpressionsAndReturnValue(context.Background(), key, user, updates)
+			Expect(err).To(BeNil())
+			Expect(user.UserName).To(Equal("new-name"))
+		})
+
+		It("should return error from dynamodb", func() {
+			key := djoemo.Key().WithTableName(UserTableName).
+				WithHashKeyName("UUID").WithHashKey("uuid")
+
+			dbErr := errors.New("update failed")
+			dAPIMock.EXPECT().
+				UpdateItemWithContext(gomock.Any(), gomock.Any()).
+				Return(nil, dbErr).
+				AnyTimes()
+
+			metricsMock.EXPECT().Record(gomock.Any(), djoemo.OpUpdate, key, gomock.Any(), false)
+
+			user := &User{}
+			updates := djoemo.UpdateExpressions{
+				djoemo.Set: {"UserName": "name"},
+			}
+
+			err := repository.UpdateWithUpdateExpressionsAndReturnValue(context.Background(), key, user, updates)
+			Expect(err).To(Equal(dbErr))
+		})
+	})
+
+	Describe("ConditionalUpdateWithUpdateExpressionsAndReturnValue", func() {
+		It("should fail with invalid key", func() {
+			key := djoemo.Key().WithHashKeyName("UUID").WithHashKey("uuid")
+			metricsMock.EXPECT().Record(gomock.Any(), djoemo.OpUpdate, key, gomock.Any(), false)
+
+			user := &User{}
+			updates := djoemo.UpdateExpressions{
+				djoemo.Set: {"UserName": "name"},
+			}
+
+			updated, err := repository.ConditionalUpdateWithUpdateExpressionsAndReturnValue(
+				context.Background(), key, user, updates, "attribute_exists(UUID)")
+			Expect(err).To(Equal(djoemo.ErrInvalidTableName))
+			Expect(updated).To(BeFalse())
+		})
+
+		It("should update when condition met and return value", func() {
+			key := djoemo.Key().WithTableName(UserTableName).
+				WithHashKeyName("UUID").WithHashKey("uuid")
+
+			updated := map[string]interface{}{
+				"UUID":     "uuid",
+				"UserName": "conditional-name",
+			}
+			av, _ := dynamodbattribute.MarshalMap(updated)
+
+			dAPIMock.EXPECT().
+				UpdateItemWithContext(gomock.Any(), gomock.Any()).
+				Return(&dynamodb.UpdateItemOutput{Attributes: av}, nil).
+				AnyTimes()
+
+			metricsMock.EXPECT().Record(gomock.Any(), djoemo.OpUpdate, key, gomock.Any(), true)
+
+			user := &User{}
+			updates := djoemo.UpdateExpressions{
+				djoemo.Set: {"UserName": "conditional-name"},
+			}
+
+			ok, err := repository.ConditionalUpdateWithUpdateExpressionsAndReturnValue(
+				context.Background(), key, user, updates, "attribute_exists(UUID)")
+			Expect(err).To(BeNil())
+			Expect(ok).To(BeTrue())
+			Expect(user.UserName).To(Equal("conditional-name"))
+		})
+
+		It("should return false and nil when ConditionalCheckFailed", func() {
+			key := djoemo.Key().WithTableName(UserTableName).
+				WithHashKeyName("UUID").WithHashKey("uuid")
+
+			condErr := awserr.New(dynamodb.ErrCodeConditionalCheckFailedException, "cond failed", nil)
+
+			dAPIMock.EXPECT().
+				UpdateItemWithContext(gomock.Any(), gomock.Any()).
+				Return(nil, condErr).
+				AnyTimes()
+
+			metricsMock.EXPECT().Record(gomock.Any(), djoemo.OpUpdate, key, gomock.Any(), false)
+			logMock.EXPECT().WithContext(gomock.Any()).Return(logMock)
+			logMock.EXPECT().WithField(djoemo.TableName, UserTableName).Return(logMock)
+			logMock.EXPECT().Info(dynamodb.ErrCodeConditionalCheckFailedException)
+
+			user := &User{}
+			updates := djoemo.UpdateExpressions{
+				djoemo.Set: {"UserName": "name"},
+			}
+
+			ok, err := repository.ConditionalUpdateWithUpdateExpressionsAndReturnValue(
+				context.Background(), key, user, updates, "attribute_exists(UUID)")
+			Expect(err).To(BeNil())
+			Expect(ok).To(BeFalse())
+		})
+
+		It("should return false and error for other dynamo errors", func() {
+			key := djoemo.Key().WithTableName(UserTableName).
+				WithHashKeyName("UUID").WithHashKey("uuid")
+
+			dbErr := errors.New("some dynamo error")
+
+			dAPIMock.EXPECT().
+				UpdateItemWithContext(gomock.Any(), gomock.Any()).
+				Return(nil, dbErr).
+				AnyTimes()
+
+			metricsMock.EXPECT().Record(gomock.Any(), djoemo.OpUpdate, key, gomock.Any(), false)
+
+			user := &User{}
+			updates := djoemo.UpdateExpressions{
+				djoemo.Set: {"UserName": "name"},
+			}
+
+			ok, err := repository.ConditionalUpdateWithUpdateExpressionsAndReturnValue(
+				context.Background(), key, user, updates, "attribute_exists(UUID)")
+			Expect(err).To(HaveOccurred())
+			Expect(ok).To(BeFalse())
+		})
+
+		It("should propagate error from prepareUpdate when SetExpr has invalid value", func() {
+			key := djoemo.Key().WithTableName(UserTableName).
+				WithHashKeyName("UUID").WithHashKey("uuid")
+
+			metricsMock.EXPECT().Record(gomock.Any(), djoemo.OpUpdate, key, gomock.Any(), false)
+
+			user := &User{}
+			updates := djoemo.UpdateExpressions{
+				djoemo.SetExpr: {"Meta.$ = ?": "not a slice"},
+			}
+
+			ok, err := repository.ConditionalUpdateWithUpdateExpressionsAndReturnValue(
+				context.Background(), key, user, updates, "attribute_exists(UUID)")
+			Expect(err).To(Equal(djoemo.ErrInvalidSliceType))
+			Expect(ok).To(BeFalse())
+		})
+	})
+})

--- a/repository_update_test.go
+++ b/repository_update_test.go
@@ -70,17 +70,6 @@ var _ = Describe("Repository", func() {
 				err := repository.UpdateWithContext(context.Background(), djoemo.Set, key, updates)
 				Expect(err).To(Equal(djoemo.ErrInvalidHashKeyValue))
 			})
-			It("should fail with hash key value is empty string", func() {
-				key := djoemo.Key().WithTableName(UserTableName).WithHashKeyName("UUID").WithHashKey("")
-				metricsMock.EXPECT().Record(gomock.Any(), djoemo.OpUpdate, key, gomock.Any(), false)
-				updates := map[string]interface{}{
-					"UserName": "name2",
-					"TraceID":  "name4",
-				}
-
-				err := repository.UpdateWithContext(context.Background(), djoemo.Set, key, updates)
-				Expect(err).To(Equal(djoemo.ErrInvalidHashKeyValue))
-			})
 		})
 
 		It("should Update item with Set", func() {
@@ -106,54 +95,6 @@ var _ = Describe("Repository", func() {
 			}
 
 			err := repository.UpdateWithContext(context.Background(), djoemo.Set, key, updates)
-			Expect(err).To(BeNil())
-		})
-
-		It("should skip empty string values in Set update", func() {
-			key := djoemo.Key().WithTableName(UserTableName).
-				WithHashKeyName("UUID").
-				WithHashKey("uuid")
-
-			dMock.Should().Update(
-				dMock.WithTable(key.TableName()),
-				dMock.WithMatch(
-					mock.InputExpect().
-						FieldEq("UserName", "name2"),
-				),
-			).Exec()
-
-			metricsMock.EXPECT().Record(gomock.Any(), djoemo.OpUpdate, key, gomock.Any(), true)
-
-			updates := map[string]interface{}{
-				"UserName": "name2",
-				"DeviceID": "",
-			}
-
-			err := repository.UpdateWithContext(context.Background(), djoemo.Set, key, updates)
-			Expect(err).To(BeNil())
-		})
-
-		It("should skip empty string values in SetIfNotExists update", func() {
-			key := djoemo.Key().WithTableName(UserTableName).
-				WithHashKeyName("UUID").
-				WithHashKey("uuid")
-
-			dMock.Should().Update(
-				dMock.WithTable(key.TableName()),
-				dMock.WithMatch(
-					mock.InputExpect().
-						FieldEq("SDKHash", "hash123"),
-				),
-			).Exec()
-
-			metricsMock.EXPECT().Record(gomock.Any(), djoemo.OpUpdate, key, gomock.Any(), true)
-
-			updates := map[string]interface{}{
-				"SDKHash":    "hash123",
-				"DeviceName": "",
-			}
-
-			err := repository.UpdateWithContext(context.Background(), djoemo.SetIfNotExists, key, updates)
 			Expect(err).To(BeNil())
 		})
 
@@ -271,82 +212,6 @@ var _ = Describe("Repository", func() {
 
 			ret := repository.UpdateWithContext(context.Background(), djoemo.Set, key, updates)
 			Expect(ret).To(Equal(err))
-		})
-	})
-
-	Describe("UpdateWithUpdateExpressions", func() {
-		It("should update item with mixed Set and SetIfNotExists expressions", func() {
-			key := djoemo.Key().WithTableName(UserTableName).
-				WithHashKeyName("UUID").
-				WithHashKey("uuid")
-
-			dMock.Should().Update(
-				dMock.WithTable(key.TableName()),
-				dMock.WithMatch(
-					mock.InputExpect().
-						FieldEq("UserName", "name2").FieldEq("SDKHash", "hash123"),
-				),
-			).Exec()
-
-			metricsMock.EXPECT().Record(gomock.Any(), djoemo.OpUpdate, key, gomock.Any(), true)
-
-			updateExpressions := djoemo.UpdateExpressions{
-				djoemo.Set: {
-					"UserName": "name2",
-				},
-				djoemo.SetIfNotExists: {
-					"SDKHash": "hash123",
-				},
-			}
-
-			err := repository.UpdateWithUpdateExpressions(context.Background(), key, updateExpressions)
-			Expect(err).To(BeNil())
-		})
-
-		It("should fail with hash key value is empty string", func() {
-			key := djoemo.Key().WithTableName(UserTableName).WithHashKeyName("UUID").WithHashKey("")
-			metricsMock.EXPECT().Record(gomock.Any(), djoemo.OpUpdate, key, gomock.Any(), false)
-
-			updateExpressions := djoemo.UpdateExpressions{
-				djoemo.Set: {
-					"UserName": "name2",
-				},
-			}
-
-			err := repository.UpdateWithUpdateExpressions(context.Background(), key, updateExpressions)
-			Expect(err).To(Equal(djoemo.ErrInvalidHashKeyValue))
-		})
-
-		It("should skip empty string values in Set and SetIfNotExists expressions", func() {
-			key := djoemo.Key().WithTableName(UserTableName).
-				WithHashKeyName("UUID").
-				WithHashKey("uuid")
-
-			dMock.Should().Update(
-				dMock.WithTable(key.TableName()),
-				dMock.WithMatch(
-					mock.InputExpect().
-						FieldEq("UserName", "name2").FieldEq("SDKHash", "hash123"),
-				),
-			).Exec()
-
-			metricsMock.EXPECT().Record(gomock.Any(), djoemo.OpUpdate, key, gomock.Any(), true)
-
-			updateExpressions := djoemo.UpdateExpressions{
-				djoemo.Set: {
-					"UserName":    "name2",
-					"DeviceID":    "",
-					"ProductName": "",
-				},
-				djoemo.SetIfNotExists: {
-					"SDKHash":    "hash123",
-					"DeviceName": "",
-					"DeviceType": "",
-				},
-			}
-
-			err := repository.UpdateWithUpdateExpressions(context.Background(), key, updateExpressions)
-			Expect(err).To(BeNil())
 		})
 	})
 


### PR DESCRIPTION
Reverts adjoeio/djoemo#28

**Issue:** All the SaveItemsWithContext fail!
**Reason:**
This check is being applied to SaveItemsWithContext where hashkey is not required
```
	if str, ok := key.HashKey().(string); ok && str == "" {
		return ErrInvalidHashKeyValue
	}
```